### PR TITLE
Set locale.conf during installation

### DIFF
--- a/http/install-chroot.sh
+++ b/http/install-chroot.sh
@@ -6,6 +6,7 @@ set -x
 ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 sed -i -e 's/^#\(en_US.UTF-8\)/\1/' /etc/locale.gen
 locale-gen
+echo 'LANG=en_US.UTF-8' > /etc/locale.conf
 
 # setting vagrant user credentials
 echo -e 'vagrant\nvagrant' | passwd

--- a/provision/postinstall.sh
+++ b/provision/postinstall.sh
@@ -5,7 +5,6 @@ set -x
 
 # setting hostname, locales, etc
 hostnamectl set-hostname "archlinux"
-localectl set-locale "LANG=en_US.UTF-8"
 localectl set-keymap "us"
 localectl set-x11-keymap "us"
 timedatectl set-ntp true


### PR DESCRIPTION
Hello, I'm running some builds with:
`$ packer build -only=virtualbox-iso vagrant.json`
and the build get stuck in the following screen:
![message_1](https://user-images.githubusercontent.com/13059863/27775568-481001e2-5f71-11e7-9f7a-ee38ae52ecf0.png)
![message_2](https://user-images.githubusercontent.com/13059863/27775569-4abd64ca-5f71-11e7-91da-fa28eba2f399.png)
Setting locale.conf during system installation fixes this problem.