### PR TITLE
Write zeros to disk to improve disk compression

### DIFF
--- a/provision/cleanup.sh
+++ b/provision/cleanup.sh
@@ -4,3 +4,9 @@ set -e
 set -x
 
 yes | sudo pacman -Scc
+
+# Write zeros to improve virtual disk compaction.
+zerofile=$(/usr/bin/mktemp /zerofile.XXXXX)
+dd if=/dev/zero of="$zerofile" bs=1M || true
+rm -f "$zerofile"
+sync


### PR DESCRIPTION
Write zeros to a file on the root partition until the filesystem is full, then unlink the file. Packer will compress the disk as part of the build, resulting in smaller final disk image.

The same strategy is used in the hashicorp/atlas-packer-vagrant-tutorial repo, here:
https://github.com/hashicorp/atlas-packer-vagrant-tutorial/blob/master/scripts/zerodisk.sh

After this change, the virtualbox box file size was reduced by ~230MB on my system:

```shell
[ma@march arch-boxes]? du -h Arch-Linux-x86_64-virtualbox-2017-08-02-*
434M    Arch-Linux-x86_64-virtualbox-2017-08-02-after.box
667M    Arch-Linux-x86_64-virtualbox-2017-08-02-before.box
```

I've only tested this change with the virtualbox-iso provider. I have reason to believe it works with the vmare-iso and qemu providers as well, as I contributed a [similar change to the packer-arch repo](https://github.com/elasticdog/packer-arch/pull/46) a while back and they have enabled it for vmware, qemu, and parallels providers. But if it turns out it breaks things for other providers, I can move it into a separate provisioner that has an `"only": ["virtualbox-iso"]` clause, if necessary.