### PR TITLE
replace iso_checksum with iso_checksum_url

### DIFF
--- a/vagrant.json
+++ b/vagrant.json
@@ -1,8 +1,8 @@
 {
     "variables": {
         "iso_url": "https://downloads.archlinux.de/iso/{{isotime \"2006.01\"}}.01/archlinux-{{isotime \"2006.01\"}}.01-x86_64.iso",
+        "iso_checksum_url": "https://downloads.archlinux.de/iso/{{isotime \"2006.01\"}}.01/sha1sums.txt",
         "iso_checksum_type": "sha1",
-        "iso_checksum": "bb609f8dfb7ece06ba3cdc355b627aab763639d3",
         "disk_size": "20480",
         "memory": "1024",
         "cpus": "2",


### PR DESCRIPTION
By replacing iso_checksum with iso_checksum_url there is no need to
hardcode hash values into vagrant.json.

Trying to add mirror variable leeds to errors: vars inside variables are not
reusable. See packer issue [#874](https://github.com/hashicorp/packer/issues/874).