### PR TITLE
Make travis validate json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: generic
+dist: trusty
+sudo: false
+
+env:
+  matrix:
+  - DIST=trusty
+  global:
+  - PACKER_ZIP="packer_1.0.4_linux_amd64.zip"
+  - PACKER_URL="https://releases.hashicorp.com/packer/1.0.4/packer_1.0.4_linux_amd64.zip"
+
+install:
+- wget "${PACKER_URL}"
+- unzip "${PACKER_ZIP}"
+
+script:
+- ./packer --version
+- ./packer validate vagrant.json
+
+notifications:
+  - email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   matrix:
   - DIST=trusty
   global:
+    # 20170821: as of writing there is no 'latest' (hashicorp/packer/issues/5265)
   - PACKER_ZIP="packer_1.0.4_linux_amd64.zip"
   - PACKER_URL="https://releases.hashicorp.com/packer/1.0.4/packer_1.0.4_linux_amd64.zip"
 


### PR DESCRIPTION
As I broke `vagrant.json` (#21) and fixed it (#22) I want to prevent this.

At https://travis-ci.org/kBite/arch-boxes/builds/266753922 you find `.travis.yml` output building my branch which is based on master and fails as expected.

`packer` version is currently hardcoded, because there is no 'latest' (see hashicorp/packer/issues/<span></span>5265).