### PR TITLE
fixed #34

### DIFF
--- a/local.json
+++ b/local.json
@@ -1,5 +1,5 @@
 {
-    "iso_url": "https://mirror.rackspace.com/archlinux/iso/latest/archlinux-2018.04.01-x86_64.iso",
+    "iso_url": "https://mirror.rackspace.com/archlinux/iso/latest/archlinux-2018.10.01-x86_64.iso",
     "iso_checksum_url": "https://mirror.rackspace.com/archlinux/iso/latest/sha1sums.txt",
     "iso_checksum_type": "sha1",
     "disk_size": "20480",

--- a/provision/postinstall.sh
+++ b/provision/postinstall.sh
@@ -6,7 +6,6 @@ set -x
 # setting hostname, locales, etc
 hostnamectl set-hostname "archlinux"
 localectl set-keymap "us"
-localectl set-x11-keymap "us"
 timedatectl set-ntp true
 
 #setting link to systemd-resolved


### PR DESCRIPTION
systemd is checking for xorg now, when trying to apply `localectl
set-x11-keymap`. So we just remove that line (we are not shipping boxes
with X11 either)

We have also updated the date for the local.json example file

Signed-off-by: Christian Rebischke <chris@nullday.de>