### PR TITLE
Replace Atlas Cloud with Vagrant Cloud.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 script:
 - ./packer --version
 - # ./packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt"  vagrant.json
-- jq 'del(."vagrant-cloud")' vagrant.json | packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt" -
+- jq ".\"post-processors\"[0] |= map(select(."type" != \"vagrant-cloud\"))" | packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt" -
 
 notifications:
   - email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ install:
 script:
 - ./packer --version
 - # ./packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt"  vagrant.json
-- jq ".\"post-processors\"[0] |= map(select(.\"type\" != \"vagrant-cloud\"))" vagrant.json | packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt" -
-- jq ".\"post-processors\"[0] |= map(select(.\"type\" != \"vagrant-cloud\"))" vagrant.json 
+- jq ".\"post-processors\"[0] |= map(select(.\"type\" != \"vagrant-cloud\"))" vagrant.json | ./packer validate -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt" -
 
 notifications:
   - email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ env:
   - DIST=trusty
   global:
     # 20170821: as of writing there is no 'latest' (hashicorp/packer/issues/5265)
-  - # PACKER_CURRENT_VERSION="$(curl -s https://checkpoint-api.hashicorp.com/v1/check/packer | jq -r -M '.current_version')"
-  - export PACKER_CURRENT_VERSION=1.3.1
+  - PACKER_CURRENT_VERSION="$(curl -s https://checkpoint-api.hashicorp.com/v1/check/packer | jq -r -M '.current_version')"
   - PACKER_URL="https://releases.hashicorp.com/packer/$PACKER_CURRENT_VERSION/packer_${PACKER_CURRENT_VERSION}_linux_amd64.zip"
   - PACKER_SHA256="https://releases.hashicorp.com/packer/$PACKER_CURRENT_VERSION/packer_${PACKER_CURRENT_VERSION}_SHA256SUMS"
   - PACKER_SHA256_SIG="https://releases.hashicorp.com/packer/$PACKER_CURRENT_VERSION/packer_${PACKER_CURRENT_VERSION}_SHA256SUMS.sig"
@@ -29,7 +28,8 @@ install:
 
 script:
 - ./packer --version
-- ./packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt"  vagrant.json
+- # ./packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt"  vagrant.json
+- jq 'del(."vagrant-cloud")' vagrant.json | packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt" -
 
 notifications:
   - email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 script:
 - ./packer --version
 - # ./packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt"  vagrant.json
-- jq ".\"post-processors\"[0] |= map(select(."type" != \"vagrant-cloud\"))" | packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt" -
+- jq ".\"post-processors\"[0] |= map(select(."type" != \"vagrant-cloud\"))" vagrant.json | packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt" -
 
 notifications:
   - email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ install:
 - unzip packer_${PACKER_CURRENT_VERSION}_linux_amd64.zip
 
 script:
-- env
 - ./packer --version
 - ./packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt"  vagrant.json
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
 - ./packer --version
 - # ./packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt"  vagrant.json
 - jq ".\"post-processors\"[0] |= map(select(.\"type\" != \"vagrant-cloud\"))" vagrant.json | packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt" -
+- jq ".\"post-processors\"[0] |= map(select(.\"type\" != \"vagrant-cloud\"))" vagrant.json 
 
 notifications:
   - email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ env:
   - DIST=trusty
   global:
     # 20170821: as of writing there is no 'latest' (hashicorp/packer/issues/5265)
-  - PACKER_CURRENT_VERSION="$(curl -s https://checkpoint-api.hashicorp.com/v1/check/packer | jq -r -M '.current_version')"
+  - # PACKER_CURRENT_VERSION="$(curl -s https://checkpoint-api.hashicorp.com/v1/check/packer | jq -r -M '.current_version')"
+  - export PACKER_CURRENT_VERSION=1.3.1
   - PACKER_URL="https://releases.hashicorp.com/packer/$PACKER_CURRENT_VERSION/packer_${PACKER_CURRENT_VERSION}_linux_amd64.zip"
   - PACKER_SHA256="https://releases.hashicorp.com/packer/$PACKER_CURRENT_VERSION/packer_${PACKER_CURRENT_VERSION}_SHA256SUMS"
   - PACKER_SHA256_SIG="https://releases.hashicorp.com/packer/$PACKER_CURRENT_VERSION/packer_${PACKER_CURRENT_VERSION}_SHA256SUMS.sig"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
 - unzip packer_${PACKER_CURRENT_VERSION}_linux_amd64.zip
 
 script:
+- env
 - ./packer --version
 - ./packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt"  vagrant.json
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 script:
 - ./packer --version
 - # ./packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt"  vagrant.json
-- jq ".\"post-processors\"[0] |= map(select(."type" != \"vagrant-cloud\"))" vagrant.json | packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt" -
+- jq ".\"post-processors\"[0] |= map(select(.\"type\" != \"vagrant-cloud\"))" vagrant.json | packer validate  -var "iso_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/archlinux-$(date +'%Y.%m').01-x86_64.iso" -var "iso_checksum_url=https://downloads.archlinux.de/iso/$(date +'%Y.%m').01/sha1sums.txt" -
 
 notifications:
   - email: false

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Here is an overview over all variables you can set in `vagrant.json` or
 * `memory`: this specifies the size of the RAM in bytes.
 * `cpus`: this specifies the number of cores for your VM.
 * `headless`: this sets GUI on or off.
-* `atlas_token`: here you can specify the atlas token for uploading your
-  box to the vagrantcloud. If you don't have any atlas token you can
-  ignore this variable. But then don't be suprised when the process
-  fails. The boxes are build, they just haven't been uploaded.
+* `vagrant_cloud_token`: here you can specify the vagrant cloud token for 
+  uploading your box to the vagrantcloud. If you don't have a vagrant cloud 
+  token you can ignore this variable. Without a token the boxes will be
+  built, but the upload step step will fail.
 * `write_zeroes`: this variable is empty. if you set any string in this
   variable it will fill the box with zeros to reduce the size. **DO NOT
   use this if you are running a SSD. It will harm your SSDs lifetime**

--- a/local.json
+++ b/local.json
@@ -6,7 +6,7 @@
     "memory": "1024",
     "cpus": "2",
     "headless": "true",
-    "atlas_token": "PLACEHOLDER",
+    "vagrant_cloud_token": "PLACEHOLDER",
     "write_zeroes": "",
     "boot_wait": "60s"
 

--- a/vagrant.json
+++ b/vagrant.json
@@ -90,7 +90,8 @@
             "ssh_wait_timeout": "10000s",
             "shutdown_command": "sudo systemctl poweroff",
             "headless": "{{user `headless`}}",
-            "vmx_data": {"memsize": "{{user `memory`}}"},
+            "memory": "{{user `memory`}}",
+            "cpus": "{{user `cpus`}}",
             "boot_command": [
                 "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter>",
                 "curl -O 'http://{{.HTTPIP}}:{{.HTTPPort}}/install{,-chroot}.sh'<enter><wait>",

--- a/vagrant.json
+++ b/vagrant.json
@@ -90,8 +90,7 @@
             "ssh_wait_timeout": "10000s",
             "shutdown_command": "sudo systemctl poweroff",
             "headless": "{{user `headless`}}",
-            "memory": "{{user `memory`}}",
-            "cpus": "{{user `cpus`}}",
+            "vmx_data": {"memsize": "{{user `memory`}}"},
             "boot_command": [
                 "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter>",
                 "curl -O 'http://{{.HTTPIP}}:{{.HTTPPort}}/install{,-chroot}.sh'<enter><wait>",

--- a/vagrant.json
+++ b/vagrant.json
@@ -7,7 +7,7 @@
         "memory": "1024",
         "cpus": "2",
         "headless": "true",
-        "atlas_token": "PLACEHOLDER",
+        "vagrant_cloud_token": "PLACEHOLDER",
         "write_zeroes": "",
         "boot_wait": "60s"
     },
@@ -148,21 +148,21 @@
             {
                 "type": "vagrant-cloud",
                 "only": ["virtualbox-iso"],
-                "access_token": "{{user `atlas_token`}}",
+                "access_token": "{{user `vagrant_cloud_token`}}",
                 "box_tag": "archlinux/archlinux",
                 "version": "{{isotime \"2006.01.02\"}}"
             },
             {
                 "type": "vagrant-cloud",
                 "only": ["qemu"],
-                "access_token": "{{user `atlas_token`}}",
+                "access_token": "{{user `vagrant_cloud_token`}}",
                 "box_tag": "archlinux/archlinux",
                 "version": "{{isotime \"2006.01.02\"}}"
             },
             {
                 "type": "vagrant-cloud",
                 "only": ["vmware-iso"],
-                "access_token": "{{user `atlas_token`}}",
+                "access_token": "{{user `vagrant_cloud_token`}}",
                 "box_tag": "archlinux/archlinux",
                 "version": "{{isotime \"2006.01.02\"}}"
             }


### PR DESCRIPTION
I updated the JSON and README file to say/use a Vagrant Cloud variable instead of Atlas, which was deprecated/decommissioned quite awhile ago.

Ideally the templates should also be able to use a VAGRANT_CLOUD_TOKEN environment variable, but I don't know off the top if it's possible to support both methods for setting an access token. With the environment variable, the access token parameter is unnecessary.