### PR TITLE
pacstrap: set up the image using NoExtract rules to prune dead weight

### DIFF
--- a/http/install.sh
+++ b/http/install.sh
@@ -25,7 +25,21 @@ mkswap "${device}1"
 mkfs.btrfs -L "rootfs" "${device}2"
 mount "${device}2" /mnt
 
-pacstrap /mnt base grub openssh sudo polkit btrfs-progs haveged
+cp /etc/pacman.conf .
+cat << __EOF__ >> pacman.conf
+[options]
+NoExtract  = usr/share/help/* !usr/share/help/en*
+NoExtract  = usr/share/gtk-doc/html/* usr/share/doc/*
+NoExtract  = usr/share/locale/* usr/share/X11/locale/* usr/share/i18n/*
+NoExtract   = !*locale*/en*/* !usr/share/i18n/charmaps/UTF-8.gz !usr/share/*locale*/locale.*
+NoExtract   = !usr/share/*locales/en_?? !usr/share/*locales/i18n* !usr/share/*locales/iso*
+NoExtract   = !usr/share/*locales/trans*
+NoExtract  = usr/share/man/* usr/share/info/*
+NoExtract  = usr/share/vim/vim*/lang/*
+__EOF__
+
+pacstrap -C ./pacman.conf /mnt base grub openssh sudo polkit btrfs-progs haveged
+cp pacman.conf /mnt/etc/pacman.conf
 swapon "${device}1"
 genfstab -p /mnt >> /mnt/etc/fstab
 swapoff "${device}1"


### PR DESCRIPTION
A virtual machine image does not need tons of locales in order to do its job, nor does it need extensive (or any) documentation.

With this change, a bare pacstrapped directory drops from 1.3GB to 1.1GB