### PR TITLE
Got it working on Windows 10 + some other misc stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ If you want to build and publish to Vagrant cloud, then run the following comman
 
 `packer build -only=virtualbox-iso -var-file=local.json vagrant.json`
 
+On Windows, add the built box to vagrant with the following command, except fix the date at the end:
+
+`vagrant box add --name archlinux_base 'Arch-Linux-x86_64-virtualbox-2019-05-17.box'`
+
 ## how to start the build process for official builds
 The official builds are done on our Arch Linux Buildserver.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,11 @@ If you want to build and publish to Vagrant cloud, then run the following comman
 
 `packer build -only=virtualbox-iso -var-file=local.json vagrant.json`
 
-On Windows, add the built box to vagrant with the following command, except fix the date at the end:
+When packer outputs `Waiting for SSH to become available...`, then the VM is ready to accept an RDP connection. A few lines above that line should be the RDP URL. Copy-paste that URL into your favorite RDP client (Windows already comes with a decent one called `Windows Desktop Connection`), and open that connection. Now you're watching packer's boot commands execute.
+
+TODO: Document how to use a text-only command line RDP client for Windows that can be run from Git Bash.
+
+Add the built box to vagrant with the following command, except fix the date at the end:
 
 `vagrant box add --name archlinux_base 'Arch-Linux-x86_64-virtualbox-2019-05-17.box'`
 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,17 @@ jq --join-output '.["post-processors"][0] |= map(select(.type == "vagrant"))' va
 && rm vagrant_local.json
 ```
 
+In [Cmder](https://cmder.net/) on Windows, which is persnickety with quotation marks, that command would be the following:
+
+`jq --join-output ".[\"post-processors\"][0] |= map(select(.type == \"vagrant\"))" vagrant.json | tr -d "\r" > vagrant_local.json && packer build -only=virtualbox-iso -var-file=local.json vagrant_local.json && rm vagrant_local.json`
+
 `jq` is used to preprocess `vagrant.json` so that only the `vagrant` post-processor is triggered, thus skipping publishing build artifacts to Vagrant cloud. The reason `jq` isn't being piped into packer is because it's more stable to fully unbuffer into a temporary file (`vagrant_local.json`), then pass that file into the packer build, then remove it.
 
 If you want to build and publish to Vagrant cloud, then run the following command:
 
 `packer build -only=virtualbox-iso -var-file=local.json vagrant.json`
 
-When packer outputs `Waiting for SSH to become available...`, then the VM is ready to accept an RDP connection. A few lines above that line should be the RDP URL. Copy-paste that URL into your favorite RDP client (Windows already comes with a decent one called `Windows Desktop Connection`), and open that connection. Now you're watching packer's boot commands execute.
+When packer outputs `Waiting for SSH to become available...`, then the VM is ready to accept an RDP connection. A few lines above that line should be the RDP URL. Copy-paste that URL into your favorite RDP client (Windows already comes with a decent one called `Windows Desktop Connection`), and open that connection. Now you're watching packer's boot commands execute. If your RDP client can't connect, then open `VirtualBox`, select the packer VM, and click the `Show` button.
 
 TODO: Document how to use a text-only command line RDP client for Windows that can be run from Git Bash.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ Edit the `local.json` before you start the build. set the right
 for virtualbox only with the following command:
 
 ```bash
-jq '.["post-processors"][0] |= map(select(.type == "vagrant"))' vagrant.json > vagrant_local.json \
+jq --join-output '.["post-processors"][0] |= map(select(.type == "vagrant"))' vagrant.json \
+| tr -d '\r' \
+> vagrant_local.json \
 && packer build -only=virtualbox-iso -var-file=local.json vagrant_local.json \
 && rm vagrant_local.json
 ```

--- a/local.json
+++ b/local.json
@@ -1,6 +1,6 @@
 {
-    "iso_url": "https://mirror.rackspace.com/archlinux/iso/latest/archlinux-2018.10.01-x86_64.iso",
-    "iso_checksum_url": "https://mirror.rackspace.com/archlinux/iso/latest/sha1sums.txt",
+    "iso_url": "https://ftp.wrz.de/pub/archlinux/iso/latest/archlinux-2019.05.02-x86_64.iso",
+    "iso_checksum_url": "https://ftp.wrz.de/pub/archlinux/iso/latest/sha1sums.txt",
     "iso_checksum_type": "sha1",
     "disk_size": "20480",
     "memory": "1024",
@@ -9,5 +9,4 @@
     "vagrant_cloud_token": "PLACEHOLDER",
     "write_zeroes": "",
     "boot_wait": "60s"
-
 }

--- a/provision/virtualbox.sh
+++ b/provision/virtualbox.sh
@@ -3,5 +3,6 @@
 set -e
 set -x
 
-sudo pacman -S --noconfirm virtualbox-guest-utils-nox virtualbox-guest-modules-arch
+sudo pacman -Syy
+yes | sudo pacman -Syy virtualbox-guest-utils-nox virtualbox-guest-modules-arch
 sudo systemctl enable vboxservice

--- a/vagrant.json
+++ b/vagrant.json
@@ -44,6 +44,10 @@
             ],
             "boot_command": [
                 "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter>",
+                "useradd -m -d /home/vagrant -g root vagrant || /bin/true<enter><wait>",
+                "echo vagrant:vagrant | chpasswd<enter><wait>",
+                "echo 'vagrant ALL=(ALL) ALL' | EDITOR='tee -a' visudo<enter><wait>",
+                "systemctl enable sshd<enter><wait>",
                 "curl -O 'http://{{.HTTPIP}}:{{.HTTPPort}}/install{,-chroot}.sh'<enter><wait>",
                 "bash install.sh < install-chroot.sh && systemctl reboot<enter>"
             ]
@@ -73,6 +77,10 @@
             ],
             "boot_command": [
                 "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter>",
+                "useradd -m -d /home/vagrant -g root vagrant || /bin/true<enter><wait>",
+                "echo vagrant:vagrant | chpasswd<enter><wait>",
+                "echo 'vagrant ALL=(ALL) ALL' | EDITOR='tee -a' visudo<enter><wait>",
+                "systemctl enable sshd<enter><wait>",
                 "curl -O 'http://{{.HTTPIP}}:{{.HTTPPort}}/install{,-chroot}.sh'<enter><wait>",
                 "bash install.sh < install-chroot.sh && systemctl reboot<enter>"
             ]
@@ -94,6 +102,10 @@
             "cpus": "{{user `cpus`}}",
             "boot_command": [
                 "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter>",
+                "useradd -m -d /home/vagrant -g root vagrant || /bin/true<enter><wait>",
+                "echo vagrant:vagrant | chpasswd<enter><wait>",
+                "echo 'vagrant ALL=(ALL) ALL' | EDITOR='tee -a' visudo<enter><wait>",
+                "systemctl enable sshd<enter><wait>",
                 "curl -O 'http://{{.HTTPIP}}:{{.HTTPPort}}/install{,-chroot}.sh'<enter><wait>",
                 "bash install.sh < install-chroot.sh && systemctl reboot<enter>"
             ]

--- a/vagrant.json
+++ b/vagrant.json
@@ -43,7 +43,7 @@
                 ]
             ],
             "boot_command": [
-                "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter>",
+                "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter><wait>",
                 "useradd -m -d /home/vagrant -g root vagrant || /bin/true<enter><wait>",
                 "echo vagrant:vagrant | chpasswd<enter><wait>",
                 "echo 'vagrant ALL=(ALL) ALL' | EDITOR='tee -a' visudo<enter><wait>",
@@ -76,7 +76,7 @@
                 ]
             ],
             "boot_command": [
-                "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter>",
+                "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter><wait>",
                 "useradd -m -d /home/vagrant -g root vagrant || /bin/true<enter><wait>",
                 "echo vagrant:vagrant | chpasswd<enter><wait>",
                 "echo 'vagrant ALL=(ALL) ALL' | EDITOR='tee -a' visudo<enter><wait>",
@@ -101,7 +101,7 @@
             "memory": "{{user `memory`}}",
             "cpus": "{{user `cpus`}}",
             "boot_command": [
-                "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter>",
+                "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter><wait>",
                 "useradd -m -d /home/vagrant -g root vagrant || /bin/true<enter><wait>",
                 "echo vagrant:vagrant | chpasswd<enter><wait>",
                 "echo 'vagrant ALL=(ALL) ALL' | EDITOR='tee -a' visudo<enter><wait>",


### PR DESCRIPTION
- Got it working on Windows 10
- Updated to the latest ISO (the `2019.05.02-x86_64` ISO from the `ftp.wrz.de` mirror)
- Added boot commands to create a `vagrant` sudoer user, so packer's SSH can work
- Added a [jq](https://github.com/stedolan/jq) command to the README. That command preprocesses `vagrant.json` so that only the `vagrant` post-processor runs, so normal users can skip the publishing to Vagrant cloud (otherwise they'd get a 401 Unauthorized error at the end of their packer build). The `jq` is also piped through a `tr` to remove Windows carriage returns, if they exist.
- Added another `<wait>` to fix the race condition where the boot commands try to execute before the autologin occurs