### PR TITLE
write_zeroes: flush buffers before writing zeroes

### DIFF
--- a/provision/write_zeroes.sh
+++ b/provision/write_zeroes.sh
@@ -3,6 +3,8 @@
 set -e
 set -x
 
+# Make sure unwritten data has been flushed beforehand
+sync
 # Write zeros to improve virtual disk compaction.
 zerofile=$(/usr/bin/mktemp /zerofile.XXXXX)
 dd if=/dev/zero of="$zerofile" bs=1M || true


### PR DESCRIPTION
this avoids spurious failures with e.g. btrfs' metadata backing store when alternative filesystems are used (i.e. #62)