### PR TITLE
Add netctl for vagrant networking capabilities

### DIFF
--- a/http/install.sh
+++ b/http/install.sh
@@ -25,7 +25,7 @@ mkswap "${device}1"
 mkfs.ext4 -L "rootfs" "${device}2"
 mount "${device}2" /mnt
 
-pacstrap /mnt base linux grub openssh sudo polkit haveged
+pacstrap /mnt base linux grub openssh sudo polkit haveged netctl
 swapon "${device}1"
 genfstab -p /mnt >>/mnt/etc/fstab
 swapoff "${device}1"


### PR DESCRIPTION
Hello, could we put netctl as part of the installation process as the current vagrant makes use of it for networking ?
We'll need to revert this once the networking capability will be switched to systemd-networkd.
This would fix #70.