### PR TITLE
Align on virtualbox recommendations (use vmsvga with 10M of vram) and…

### DIFF
--- a/cloud.json
+++ b/cloud.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-        "iso_url": "https://mirror.pkgbuild.com/iso/latest/archlinux-2019.10.01-x86_64.iso",
+        "iso_url": "https://mirror.pkgbuild.com/iso/latest/archlinux-{{isotime \"2006.01\"}}.01-x86_64.iso",
         "iso_checksum_url": "https://mirror.pkgbuild.com/iso/latest/sha1sums.txt",
         "iso_checksum_type": "sha1",
         "disk_size": "20480",

--- a/local.json
+++ b/local.json
@@ -1,7 +1,7 @@
 {
     "variables": {
 
-    "iso_url": "https://mirror.pkgbuild.com/iso/latest/archlinux-2019.10.01-x86_64.iso",
+    "iso_url": "https://mirror.pkgbuild.com/iso/latest/archlinux-{{isotime \"2006.01\"}}.01-x86_64.iso",
     "iso_checksum_url": "https://mirror.pkgbuild.com/iso/latest/sha1sums.txt",
     "iso_checksum_type": "sha1",
     "disk_size": "20480",
@@ -40,6 +40,18 @@
                     "{{.Name}}",
                     "--cpus",
                     "{{user `cpus`}}"
+                ],
+                [
+                    "modifyvm",
+                    "{{.Name}}",
+                    "--graphicscontroller",
+                    "vmsvga"
+                ],
+                [
+                    "modifyvm",
+                    "{{.Name}}",
+                    "--vram",
+                    "10"
                 ]
             ],
             "boot_command": [

--- a/vagrant.json
+++ b/vagrant.json
@@ -40,6 +40,18 @@
                     "{{.Name}}",
                     "--cpus",
                     "{{user `cpus`}}"
+                ],
+                [
+                    "modifyvm",
+                    "{{.Name}}",
+                    "--graphicscontroller",
+                    "vmsvga"
+                ],
+                [
+                    "modifyvm",
+                    "{{.Name}}",
+                    "--vram",
+                    "10"
                 ]
             ],
             "boot_command": [


### PR DESCRIPTION
… align json files for fetching last isos

Older versions of Virtualbox (at least the 5.12 tested) are working with this boxes too (it is just ignoring the vmsvga parameter it seems).

If iso alignment is not a good idea, please let me know, I will do a new PR.