### PR TITLE
Support specifying a mirror

### DIFF
--- a/cloud.json
+++ b/cloud.json
@@ -8,7 +8,8 @@
         "cpus": "2",
         "headless": "true",
         "write_zeroes": "",
-        "boot_wait": "60s"
+        "boot_wait": "60s",
+        "mirror": ""
     },
     "builders": [
         {
@@ -40,7 +41,7 @@
             "boot_command": [
                 "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter>",
                 "curl -O 'http://{{.HTTPIP}}:{{.HTTPPort}}/install{,-common,-cloud}.sh'<enter><wait>",
-                "bash install.sh < <(cat install-{cloud,common}.sh) && systemctl reboot<enter>"
+                "MIRROR='{{user `mirror`}}' bash install.sh < <(cat install-{cloud,common}.sh) && systemctl reboot<enter>"
             ]
         }
     ],

--- a/http/install.sh
+++ b/http/install.sh
@@ -25,9 +25,13 @@ mkswap "${device}1"
 mkfs.ext4 -L "rootfs" "${device}2"
 mount "${device}2" /mnt
 
-pacstrap /mnt base linux grub openssh sudo polkit haveged netctl python reflector
+if [ -n "${MIRROR}" ]; then
+  echo "Server = ${MIRROR}" >/etc/pacman.d/mirrorlist
+fi
+pacstrap -M /mnt base linux grub openssh sudo polkit haveged netctl python reflector
 swapon "${device}1"
 genfstab -p /mnt >>/mnt/etc/fstab
 swapoff "${device}1"
 
+arch-chroot /mnt /usr/bin/sed -i 's/^#Server/Server/' /etc/pacman.d/mirrorlist
 arch-chroot /mnt /bin/bash

--- a/local.json
+++ b/local.json
@@ -9,7 +9,8 @@
     "cpus": "2",
     "headless": "true",
     "write_zeroes": "",
-    "boot_wait": "60s"
+    "boot_wait": "60s",
+    "mirror": ""
     },
     "builders": [
         {
@@ -45,7 +46,7 @@
             "boot_command": [
                 "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter>",
                 "curl -O 'http://{{.HTTPIP}}:{{.HTTPPort}}/install{,-common,-chroot}.sh'<enter><wait>",
-                "bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
+                "MIRROR='{{user `mirror`}}' bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
             ]
         }, {
             "type": "qemu",
@@ -74,7 +75,7 @@
             "boot_command": [
                 "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter>",
                 "curl -O 'http://{{.HTTPIP}}:{{.HTTPPort}}/install{,-common,-chroot}.sh'<enter><wait>",
-                "bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
+                "MIRROR='{{user `mirror`}}' bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
             ]
         }, {
             "type": "vmware-iso",
@@ -95,7 +96,7 @@
             "boot_command": [
                 "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter>",
                 "curl -O 'http://{{.HTTPIP}}:{{.HTTPPort}}/install{,-common,-chroot}.sh'<enter><wait>",
-                "bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
+                "MIRROR='{{user `mirror`}}' bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
             ]
         }
 

--- a/vagrant.json
+++ b/vagrant.json
@@ -9,7 +9,8 @@
         "headless": "true",
         "vagrant_cloud_token": "PLACEHOLDER",
         "write_zeroes": "",
-        "boot_wait": "60s"
+        "boot_wait": "60s",
+        "mirror": ""
     },
     "builders": [
         {
@@ -45,7 +46,7 @@
             "boot_command": [
                 "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter>",
                 "curl -O 'http://{{.HTTPIP}}:{{.HTTPPort}}/install{,-common,-chroot}.sh'<enter><wait>",
-                "bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
+                "MIRROR='{{user `mirror`}}' bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
             ]
         }, {
             "type": "qemu",
@@ -74,7 +75,7 @@
             "boot_command": [
                 "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter>",
                 "curl -O 'http://{{.HTTPIP}}:{{.HTTPPort}}/install{,-common,-chroot}.sh'<enter><wait>",
-                "bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
+                "MIRROR='{{user `mirror`}}' bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
             ]
         }, {
             "type": "vmware-iso",
@@ -95,7 +96,7 @@
             "boot_command": [
                 "<enter><wait10><wait10><wait10><wait10><wait10><enter><enter>",
                 "curl -O 'http://{{.HTTPIP}}:{{.HTTPPort}}/install{,-common,-chroot}.sh'<enter><wait>",
-                "bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
+                "MIRROR='{{user `mirror`}}' bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
             ]
         }
 


### PR DESCRIPTION
Note: The mirror is only used under the bootstrapping process, the
image contains the default mirrorlist with every server uncommented.

Fix #87