### PR TITLE
Fix virtualbox build and reflector installation, as well as reflector-init.service

### DIFF
--- a/http/install-common.sh
+++ b/http/install-common.sh
@@ -61,8 +61,9 @@ EOF
 cat <<EOF >/etc/systemd/system/reflector-init.service
 [Unit]
 Description=Initializes mirrors for the VM
-After=network.target
-Wants=network.target
+After=network-online.target
+Wants=network-online.target
+Before=sshd.service
 ConditionFirstBoot=yes
 
 [Service]

--- a/http/install.sh
+++ b/http/install.sh
@@ -28,7 +28,7 @@ mount "${device}2" /mnt
 if [ -n "${MIRROR}" ]; then
   echo "Server = ${MIRROR}" >/etc/pacman.d/mirrorlist
 else
-  pacman -Sy reflector
+  pacman -Sy --noconfirm reflector
   reflector --age 12 --protocol https --sort rate --save /etc/pacman.d/mirrorlist
 fi
 pacstrap -M /mnt base linux grub openssh sudo polkit haveged netctl python reflector

--- a/provision/virtualbox.sh
+++ b/provision/virtualbox.sh
@@ -3,5 +3,5 @@
 set -e
 set -x
 
-sudo pacman -S --noconfirm virtualbox-guest-utils-nox virtualbox-guest-modules-arch
+sudo pacman -S --noconfirm virtualbox-guest-utils-nox
 sudo systemctl enable vboxservice


### PR DESCRIPTION
I wanted to investigate why reflector-init was not working with the latest boxes, and found that building the box failed. Pacman was failing to install reflector due to the missing --noconfirm, and virtualbox guest modules are now part of "linux" package directly, so there's no need to add them. I will investigate on the refector-init issue, it seems that for me reflector is trying to reach the mirror page before having DNS available.