### PR TITLE
generate fstab with UUIDs

### DIFF
--- a/http/install.sh
+++ b/http/install.sh
@@ -33,7 +33,7 @@ else
 fi
 pacstrap -M /mnt base linux grub openssh sudo polkit haveged netctl python reflector
 swapon "${device}1"
-genfstab -p /mnt >>/mnt/etc/fstab
+genfstab -pU /mnt >>/mnt/etc/fstab
 swapoff "${device}1"
 
 arch-chroot /mnt /usr/bin/sed -i 's/^#Server/Server/' /etc/pacman.d/mirrorlist


### PR DESCRIPTION
Vagrant has experimental support for adding SATA disks. Although this
box does not support that yet (at least for the virtualbox provider,
since no AHCI storage controller with the name "SATA Controller" is
included), it is possible to add another disk. This causes a boot
failure in some circumstances because although the root is set to a UUID
in the kernel cmdline, systemd's fsck still looks for /dev/sda as stated
in /etc/fstab.