### PR TITLE
JSON packer update for new packer format + cloud.json validation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,9 @@ jobs:
     - name: verify vagrant.json
       run: ./generic-ci.sh verify-official
 
+    - name: verify cloud.json
+      run: ./generic-ci.sh verify-cloud
+
   python-syntax-validation:
     runs-on: ubuntu-latest
 

--- a/cloud.json
+++ b/cloud.json
@@ -2,7 +2,6 @@
     "variables": {
         "iso_url": "https://mirror.pkgbuild.com/iso/latest/archlinux-{{isotime \"2006.01\"}}.01-x86_64.iso",
         "iso_checksum_url": "https://mirror.pkgbuild.com/iso/latest/sha1sums.txt",
-        "iso_checksum_type": "sha1",
         "disk_size": "20480",
         "memory": "1024",
         "cpus": "2",
@@ -19,8 +18,7 @@
             "boot_wait": "{{user `boot_wait`}}",
             "http_directory": "http",
             "disk_size": "{{user `disk_size`}}",
-            "iso_checksum_url": "{{user `iso_checksum_url`}}",
-            "iso_checksum_type": "{{user `iso_checksum_type`}}",
+            "iso_checksum": "file:{{user `iso_checksum_url`}}",
             "iso_url": "{{user `iso_url`}}",
             "ssh_username": "arch",
             "ssh_password": "arch",
@@ -66,19 +64,19 @@
     ],
     "post-processors": [
         [
-           {
+            {
                 "type": "checksum",
                 "checksum_types": [
-                        "sha256"
+                    "sha256"
                 ],
                 "output": "Arch-Linux-cloudimg-amd64-{{isotime \"2006-01-02\"}}.SHA256"
             },
             {
                 "type": "shell-local",
                 "inline": [
-                        "mv release/packer-Arch-Linux-cloudimg-amd64-{{isotime \"2006-01-02\"}}.img release/Arch-Linux-cloudimg-amd64-{{isotime \"2006-01-02\"}}.img",
-                        "sed -i 's/packer-//' Arch-Linux-cloudimg-amd64-{{isotime \"2006-01-02\"}}.SHA256",
-                        "gpg --sign --detach-sign Arch-Linux-cloudimg-amd64-{{isotime \"2006-01-02\"}}.SHA256"
+                    "mv release/packer-Arch-Linux-cloudimg-amd64-{{isotime \"2006-01-02\"}}.img release/Arch-Linux-cloudimg-amd64-{{isotime \"2006-01-02\"}}.img",
+                    "sed -i 's/packer-//' Arch-Linux-cloudimg-amd64-{{isotime \"2006-01-02\"}}.SHA256",
+                    "gpg --sign --detach-sign Arch-Linux-cloudimg-amd64-{{isotime \"2006-01-02\"}}.SHA256"
                 ]
             }
         ]

--- a/generic-ci.sh
+++ b/generic-ci.sh
@@ -46,6 +46,10 @@ case $1 in
     ./packer validate local.json
     ;;
 
+  verify-cloud)
+    ./packer validate cloud.json
+    ;;
+
   # We use + instead of \; here because find doesn't pass
   # the exit code through when used with \;
   shellcheck)

--- a/local.json
+++ b/local.json
@@ -1,16 +1,14 @@
 {
     "variables": {
-
-    "iso_url": "https://mirror.pkgbuild.com/iso/latest/archlinux-{{isotime \"2006.01\"}}.01-x86_64.iso",
-    "iso_checksum_url": "https://mirror.pkgbuild.com/iso/latest/sha1sums.txt",
-    "iso_checksum_type": "sha1",
-    "disk_size": "20480",
-    "memory": "1024",
-    "cpus": "2",
-    "headless": "true",
-    "write_zeroes": "",
-    "boot_wait": "60s",
-    "mirror": ""
+        "iso_url": "https://mirror.pkgbuild.com/iso/latest/archlinux-{{isotime \"2006.01\"}}.01-x86_64.iso",
+        "iso_checksum_url": "https://mirror.pkgbuild.com/iso/latest/sha1sums.txt",
+        "disk_size": "20480",
+        "memory": "1024",
+        "cpus": "2",
+        "headless": "true",
+        "write_zeroes": "",
+        "boot_wait": "60s",
+        "mirror": ""
     },
     "builders": [
         {
@@ -19,8 +17,7 @@
             "http_directory": "http",
             "disk_size": "{{user `disk_size`}}",
             "guest_os_type": "ArchLinux_64",
-            "iso_checksum_url": "{{user `iso_checksum_url`}}",
-            "iso_checksum_type": "{{user `iso_checksum_type`}}",
+            "iso_checksum": "file:{{user `iso_checksum_url`}}",
             "iso_url": "{{user `iso_url`}}",
             "ssh_username": "vagrant",
             "ssh_password": "vagrant",
@@ -48,13 +45,13 @@
                 "curl -O 'http://{{.HTTPIP}}:{{.HTTPPort}}/install{,-common,-chroot}.sh'<enter><wait>",
                 "MIRROR='{{user `mirror`}}' bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
             ]
-        }, {
+        },
+        {
             "type": "qemu",
             "boot_wait": "{{user `boot_wait`}}",
             "http_directory": "http",
             "disk_size": "{{user `disk_size`}}",
-            "iso_checksum_url": "{{user `iso_checksum_url`}}",
-            "iso_checksum_type": "{{user `iso_checksum_type`}}",
+            "iso_checksum": "file:{{user `iso_checksum_url`}}",
             "iso_url": "{{user `iso_url`}}",
             "ssh_username": "vagrant",
             "ssh_password": "vagrant",
@@ -77,13 +74,13 @@
                 "curl -O 'http://{{.HTTPIP}}:{{.HTTPPort}}/install{,-common,-chroot}.sh'<enter><wait>",
                 "MIRROR='{{user `mirror`}}' bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
             ]
-        }, {
+        },
+        {
             "type": "vmware-iso",
             "boot_wait": "{{user `boot_wait`}}",
             "http_directory": "http",
             "disk_size": "{{user `disk_size`}}",
-            "iso_checksum_url": "{{user `iso_checksum_url`}}",
-            "iso_checksum_type": "{{user `iso_checksum_type`}}",
+            "iso_checksum": "file:{{user `iso_checksum_url`}}",
             "iso_url": "{{user `iso_url`}}",
             "ssh_username": "vagrant",
             "ssh_password": "vagrant",
@@ -99,7 +96,6 @@
                 "MIRROR='{{user `mirror`}}' bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
             ]
         }
-
     ],
     "provisioners": [
         {
@@ -110,7 +106,9 @@
                 "provision/cleanup.sh"
             ],
             "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'",
-            "only": ["virtualbox-iso"]
+            "only": [
+                "virtualbox-iso"
+            ]
         },
         {
             "type": "shell",
@@ -120,7 +118,9 @@
                 "provision/cleanup.sh"
             ],
             "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'",
-            "only": ["qemu"]
+            "only": [
+                "qemu"
+            ]
         },
         {
             "type": "shell",
@@ -130,7 +130,9 @@
                 "provision/cleanup.sh"
             ],
             "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'",
-            "only": ["vmware-iso"]
+            "only": [
+                "vmware-iso"
+            ]
         },
         {
             "type": "shell",

--- a/vagrant.json
+++ b/vagrant.json
@@ -2,7 +2,6 @@
     "variables": {
         "iso_url": "file:///srv/ftp/iso/latest/archlinux-{{isotime \"2006.01\"}}.01-x86_64.iso",
         "iso_checksum_url": "file:///srv/ftp/iso/latest/sha1sums.txt",
-        "iso_checksum_type": "sha1",
         "disk_size": "20480",
         "memory": "1024",
         "cpus": "2",
@@ -19,8 +18,7 @@
             "http_directory": "http",
             "disk_size": "{{user `disk_size`}}",
             "guest_os_type": "ArchLinux_64",
-            "iso_checksum_url": "{{user `iso_checksum_url`}}",
-            "iso_checksum_type": "{{user `iso_checksum_type`}}",
+            "iso_checksum": "file:{{user `iso_checksum_url`}}",
             "iso_url": "{{user `iso_url`}}",
             "ssh_username": "vagrant",
             "ssh_password": "vagrant",
@@ -48,13 +46,13 @@
                 "curl -O 'http://{{.HTTPIP}}:{{.HTTPPort}}/install{,-common,-chroot}.sh'<enter><wait>",
                 "MIRROR='{{user `mirror`}}' bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
             ]
-        }, {
+        },
+        {
             "type": "qemu",
             "boot_wait": "{{user `boot_wait`}}",
             "http_directory": "http",
             "disk_size": "{{user `disk_size`}}",
-            "iso_checksum_url": "{{user `iso_checksum_url`}}",
-            "iso_checksum_type": "{{user `iso_checksum_type`}}",
+            "iso_checksum": "file:{{user `iso_checksum_url`}}",
             "iso_url": "{{user `iso_url`}}",
             "ssh_username": "vagrant",
             "ssh_password": "vagrant",
@@ -77,13 +75,13 @@
                 "curl -O 'http://{{.HTTPIP}}:{{.HTTPPort}}/install{,-common,-chroot}.sh'<enter><wait>",
                 "MIRROR='{{user `mirror`}}' bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
             ]
-        }, {
+        },
+        {
             "type": "vmware-iso",
             "boot_wait": "{{user `boot_wait`}}",
             "http_directory": "http",
             "disk_size": "{{user `disk_size`}}",
-            "iso_checksum_url": "{{user `iso_checksum_url`}}",
-            "iso_checksum_type": "{{user `iso_checksum_type`}}",
+            "iso_checksum": "file:{{user `iso_checksum_url`}}",
             "iso_url": "{{user `iso_url`}}",
             "ssh_username": "vagrant",
             "ssh_password": "vagrant",
@@ -99,7 +97,6 @@
                 "MIRROR='{{user `mirror`}}' bash install.sh < <(cat install-{chroot,common}.sh) && systemctl reboot<enter>"
             ]
         }
-
     ],
     "provisioners": [
         {
@@ -110,7 +107,9 @@
                 "provision/cleanup.sh"
             ],
             "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'",
-            "only": ["virtualbox-iso"]
+            "only": [
+                "virtualbox-iso"
+            ]
         },
         {
             "type": "shell",
@@ -120,7 +119,9 @@
                 "provision/cleanup.sh"
             ],
             "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'",
-            "only": ["qemu"]
+            "only": [
+                "qemu"
+            ]
         },
         {
             "type": "shell",
@@ -130,7 +131,9 @@
                 "provision/cleanup.sh"
             ],
             "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'",
-            "only": ["vmware-iso"]
+            "only": [
+                "vmware-iso"
+            ]
         },
         {
             "type": "shell",
@@ -149,21 +152,27 @@
             },
             {
                 "type": "vagrant-cloud",
-                "only": ["virtualbox-iso"],
+                "only": [
+                    "virtualbox-iso"
+                ],
                 "access_token": "{{user `vagrant_cloud_token`}}",
                 "box_tag": "archlinux/archlinux",
                 "version": "{{isotime \"2006.01.02\"}}"
             },
             {
                 "type": "vagrant-cloud",
-                "only": ["qemu"],
+                "only": [
+                    "qemu"
+                ],
                 "access_token": "{{user `vagrant_cloud_token`}}",
                 "box_tag": "archlinux/archlinux",
                 "version": "{{isotime \"2006.01.02\"}}"
             },
             {
                 "type": "vagrant-cloud",
-                "only": ["vmware-iso"],
+                "only": [
+                    "vmware-iso"
+                ],
                 "access_token": "{{user `vagrant_cloud_token`}}",
                 "box_tag": "archlinux/archlinux",
                 "version": "{{isotime \"2006.01.02\"}}"


### PR DESCRIPTION
Build was failing as packer complains for the checksum format declaration. This PR should fix this problem. cloud.json has been added to the automatic validation list. I formatted the json files using `python -m json.tool`.