### PR TITLE
allow programatic (non-interactive) use cases for QEMU image

### DIFF
--- a/images/basic.sh
+++ b/images/basic.sh
@@ -7,10 +7,7 @@ PACKAGES=()
 SERVICES=()
 
 function pre() {
-  local NEWUSER="arch"
-  arch-chroot "${MOUNT}" /usr/bin/useradd -m -U "${NEWUSER}"
-  echo -e "${NEWUSER}\n${NEWUSER}" | arch-chroot "${MOUNT}" /usr/bin/passwd "${NEWUSER}"
-  echo "${NEWUSER} ALL=(ALL) NOPASSWD: ALL" >"${MOUNT}/etc/sudoers.d/${NEWUSER}"
+  new_user_pass_same_as_name_and_vagrant_sshkey "arch"
 
   cat <<EOF >"${MOUNT}/etc/systemd/network/80-dhcp.network"
 [Match]

--- a/images/common.sh
+++ b/images/common.sh
@@ -1,10 +1,23 @@
 #!/bin/bash
 
+function new_user_pass_same_as_name_and_vagrant_sshkey(){
+  arch-chroot "${MOUNT}" /usr/bin/useradd -m -U "${1}"
+  echo -e "${1}\n${1}" | arch-chroot "${MOUNT}" /usr/bin/passwd "${1}"
+
+  # install vagrant ssh key
+  arch-chroot "${MOUNT}" /bin/bash -e <<EOF
+install --directory --owner=${1} --group=${1} --mode=0700 /home/${1}/.ssh
+curl --output /home/vagrant/.ssh/authorized_keys --location https://github.com/hashicorp/vagrant/raw/main/keys/vagrant.pub
+# WARNING: Please only update the hash if you are 100% sure it was intentionally updated by upstream.
+# NOTE: why not store the files in this repo then?
+sha256sum -c <<< "9aa9292172c915821e29bcbf5ff42d4940f59d6a148153c76ad638f5f4c6cd8b /home/vagrant/.ssh/authorized_keys"
+chown ${1}:${1} /home/${1}/.ssh/authorized_keys
+chmod 0600 /home/${1}/.ssh/authorized_keys
+EOF
+}
+
 function vagrant_common() {
-  local NEWUSER="vagrant"
-  # setting the user credentials
-  arch-chroot "${MOUNT}" /usr/bin/useradd -m -U "${NEWUSER}"
-  echo -e "${NEWUSER}\n${NEWUSER}" | arch-chroot "${MOUNT}" /usr/bin/passwd "${NEWUSER}"
+  new_user_pass_same_as_name_and_vagrant_sshkey "vagrant"
 
   # setting sudo for the user
   cat <<EOF >"${MOUNT}/etc/sudoers.d/${NEWUSER}"
@@ -22,13 +35,4 @@ Name=eth0
 DHCP=ipv4
 EOF
 
-  # install vagrant ssh key
-  arch-chroot "${MOUNT}" /bin/bash -e <<EOF
-install --directory --owner=vagrant --group=vagrant --mode=0700 /home/vagrant/.ssh
-curl --output /home/vagrant/.ssh/authorized_keys --location https://github.com/hashicorp/vagrant/raw/main/keys/vagrant.pub
-# WARNING: Please only update the hash if you are 100% sure it was intentionally updated by upstream.
-sha256sum -c <<< "9aa9292172c915821e29bcbf5ff42d4940f59d6a148153c76ad638f5f4c6cd8b /home/vagrant/.ssh/authorized_keys"
-chown vagrant:vagrant /home/vagrant/.ssh/authorized_keys
-chmod 0600 /home/vagrant/.ssh/authorized_keys
-EOF
 }


### PR DESCRIPTION
Using the QEMU file for most programatic use cases is difficult without a ssh key pre-set.

Either using the image in a vagrant qemu backend, or directly via `qemu-system-x86_64 -display none -daemonize` makes it very difficult to interact with the image since there's no way to ssh to the instance or attach qemu to std i/o without too much unrelated code (as this repo does, btw)

This change just add (and centralizes in common) the code to create the user with a known public ssh key.